### PR TITLE
slcc: conditions: fix misplaced condition

### DIFF
--- a/platform/security/component/mbedtls_config.slcc
+++ b/platform/security/component/mbedtls_config.slcc
@@ -19,7 +19,7 @@ include:
   - path: config/preset
     file_list:
       - path: sli_mbedtls_config_se_cpc_primary.h
-        condition: [se_cpc_primary]
+    condition: [se_cpc_primary]
 
 template_file:
   - path: config/template/sli_mbedtls_config_autogen.h.jinja

--- a/platform/security/component/psa_crypto_config.slcc
+++ b/platform/security/component/psa_crypto_config.slcc
@@ -23,7 +23,7 @@ include:
   - path: config/preset
     file_list:
       - path: sli_psa_config_se_cpc_primary.h
-        condition: [se_cpc_primary]
+    condition: [se_cpc_primary]
 
 template_file:
   - path: config/template/sli_psa_config_autogen.h.jinja


### PR DESCRIPTION
Previously, the condition for including certain files was applied only to the file entry within a directory. This caused the directory itself to be included in build system paths even when the condition was not met, resulting in errors due to non-existent include paths. This commit moves the condition to the directory level, ensuring that both the directory and its files are only included when the condition is satisfied. This prevents the build system from referencing invalid paths and resolves related build issues.

The same adjustment can be apply to other configuration files following this pattern.