### PR TITLE
Add DHTxx and Modbus driver folders and .slcc files

### DIFF
--- a/hardware/driver/component/dhtxx_driver.slcc
+++ b/hardware/driver/component/dhtxx_driver.slcc
@@ -1,0 +1,32 @@
+id: dhtxx_driver
+package: board_drivers
+label: DHTXX (DHT11/DHT22) - Temperature and Humidity Sensor
+description: >
+  Driver for DHT11 and DHT22 temperature and humidity sensors with configurable type selection.
+  Supports both sensor types with automatic protocol detection and pin tool integration.
+category: Platform|Board Drivers
+quality: production
+root_path: hardware/driver/dhtxx
+provides:
+  - name: dhtxx_driver
+  - name: dht_driver # Backward compatibility
+  - name: dht11_driver # Backward compatibility
+requires:
+  - name: gpio
+  - name: sleeptimer
+  - name: status
+include:
+  - path: inc
+    file_list:
+      - path: dhtxx.h
+source:
+  - path: src/dhtxx.c
+config_file:
+  - path: config/sl_dhtxx_config.h
+    file_id: dhtxx_config
+template_contribution:
+  - name: component_catalog
+    value: dhtxx_driver
+documentation:
+  docset: gecko-platform
+  document: platform-hardware-driver/dhtxx

--- a/hardware/driver/component/modbusmaster_driver.slcc
+++ b/hardware/driver/component/modbusmaster_driver.slcc
@@ -1,0 +1,27 @@
+id: modbusmaster_driver
+package: platform
+label: ModbusMaster RTU - RS485 Communication
+description: >
+  ModbusMaster RTU driver for RS485 communication with configurable DE/RE pin control.
+  Supports reading holding registers (0x03) and input registers (0x04) with pin tool integration.
+category: Platform|Board Drivers
+quality: production
+root_path: hardware/driver/modbus
+provides:
+  - name: modbusmaster_driver
+  - name: modbus_driver # Backward compatibility
+requires:
+  - name: sleeptimer
+  - name: iostream
+include:
+  - path: inc
+    file_list:
+      - path: modbusmaster.h
+source:
+  - path: src/modbusmaster.c
+config_file:
+  - path: config/sl_modbusmaster_config.h
+    file_id: modbusmaster_config
+documentation:
+  docset: gecko-platform
+  document: platform-hardware-driver/modbusmaster

--- a/hardware/driver/dhtxx/config/sl_dhtxx_config.h
+++ b/hardware/driver/dhtxx/config/sl_dhtxx_config.h
@@ -1,0 +1,61 @@
+/***************************************************************************/ /**
+                                                                               * @file
+                                                                               * @brief DHTXX Config
+                                                                               *******************************************************************************
+                                                                               * # License
+                                                                               * <b>Copyright 2023 Silicon Laboratories Inc. www.silabs.com</b>
+                                                                               *******************************************************************************
+                                                                               *
+                                                                               * SPDX-License-Identifier: Zlib
+                                                                               *
+                                                                               * The licensor of this software is Silicon Laboratories Inc.
+                                                                               *
+                                                                               * This software is provided 'as-is', without any express or implied
+                                                                               * warranty. In no event will the authors be held liable for any damages
+                                                                               * arising from the use of this software.
+                                                                               *
+                                                                               * Permission is granted to anyone to use this software for any purpose,
+                                                                               * including commercial applications, and to alter it and redistribute it
+                                                                               * freely, subject to the following restrictions:
+                                                                               *
+                                                                               * 1. The origin of this software must not be misrepresented; you must not
+                                                                               *    claim that you wrote the original software. If you use this software
+                                                                               *    in a product, an acknowledgment in the product documentation would be
+                                                                               *    appreciated but is not required.
+                                                                               * 2. Altered source versions must be plainly marked as such, and must not be
+                                                                               *    misrepresented as being the original software.
+                                                                               * 3. This notice may not be removed or altered from any source distribution.
+                                                                               *
+                                                                               ******************************************************************************/
+
+#ifndef SL_DHTXX_CONFIG_H
+#define SL_DHTXX_CONFIG_H
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> DHTXX Configuration
+
+// <o SL_DHTXX_SENSOR_TYPE> Sensor Type
+// <DHT11=> DHT11
+// <DHT22=> DHT22
+// <i> Select the DHT sensor type
+// <i> Default: DHT22
+#define SL_DHTXX_SENSOR_TYPE DHT22
+
+// </h>
+
+// <<< end of configuration section >>>
+
+// <<< sl:start pin_tool >>>
+// <gpio> SL_DHTXX_DATA
+// $[GPIO_SL_DHTXX_DATA]
+#define SL_DHTXX_DATA_PORT SL_GPIO_PORT_C
+#define SL_DHTXX_DATA_PIN 1
+// [GPIO_SL_DHTXX_DATA]$
+// <<< sl:end pin_tool >>>
+
+// DHT sensor type definitions
+#define DHT11 11
+#define DHT22 22
+
+#endif // SL_DHTXX_CONFIG_H

--- a/hardware/driver/dhtxx/inc/dhtxx.h
+++ b/hardware/driver/dhtxx/inc/dhtxx.h
@@ -1,0 +1,40 @@
+#ifndef DHTXX_H
+#define DHTXX_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "sl_dhtxx_config.h"
+
+// DHT sensor types
+typedef enum
+{
+    DHT_TYPE_DHT11 = 0,
+    DHT_TYPE_DHT22 = 1
+} DHT_Type_t;
+
+typedef struct
+{
+    uint8_t humidity_int;
+    uint8_t humidity_dec;
+    int8_t temperature_int; // Changed to signed for DHT22 negative temperatures
+    uint8_t temperature_dec;
+    uint8_t checksum;
+} DHT_Data_t;
+
+// Backward compatibility typedef
+typedef DHT_Data_t DHT11_Data_t;
+typedef DHT_Data_t DHTXX_Data_t;
+
+// Main API functions
+void DHT_Init(void);
+bool DHT_Read(DHT_Data_t *data);
+void DHT_Print(const DHT_Data_t *data);
+
+// Arduino-style API
+float DHT_ReadHumidity(void);
+float DHT_ReadTemperature(void);
+float DHT_ReadTemperatureF(void);
+
+// DHTXX API (same as DHT)
+
+#endif // DHTXX_H

--- a/hardware/driver/dhtxx/src/dhtxx.c
+++ b/hardware/driver/dhtxx/src/dhtxx.c
@@ -1,0 +1,224 @@
+/*
+ * DHT11/DHT22 reader using DWT cycle counter for microsecond timing.
+ * Measures pulse widths (in us) to distinguish 0 vs 1.
+ * Supports both DHT11 and DHT22 sensors with pin tool configuration.
+ */
+#include "dhtxx.h"
+#include "em_gpio.h"
+#include "em_core.h"
+#include "em_device.h"
+#include "em_system.h"
+#include <stdio.h>
+#include "sl_dhtxx_config.h"
+
+// Pin configuration from pin tool - cast to proper GPIO types
+#define DHT_PORT ((GPIO_Port_TypeDef)SL_DHTXX_DATA_PORT)
+#define DHT_PIN SL_DHTXX_DATA_PIN
+
+// Sensor type from configuration
+#define DHT_TYPE SL_DHTXX_SENSOR_TYPE
+
+// Timing constants for DHT11 and DHT22
+#define DHT11_START_SIGNAL_LOW_MS 20
+#define DHT22_START_SIGNAL_LOW_MS 1
+#define DHT_BIT_THRESHOLD_US 50
+
+static uint32_t cycles_per_us;
+
+static void dwt_init(void)
+{
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CYCCNT = 0;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+    cycles_per_us = SystemCoreClock / 1000000U;
+}
+
+static inline uint32_t micros(void)
+{
+    return (uint32_t)(DWT->CYCCNT / (cycles_per_us ? cycles_per_us : 1));
+}
+
+static void delay_ms(uint32_t ms)
+{
+    uint32_t start = micros();
+    while ((micros() - start) < (ms * 1000U))
+    {
+        __NOP();
+    }
+}
+
+void DHT_Init(void)
+{
+
+    dwt_init();
+    GPIO_PinModeSet(DHT_PORT, DHT_PIN, gpioModeInputPull, 1);
+}
+
+static inline void dht_drive_low(void)
+{
+    GPIO_PinModeSet(DHT_PORT, DHT_PIN, gpioModePushPull, 0);
+    GPIO_PinOutClear(DHT_PORT, DHT_PIN);
+}
+
+static inline void dht_release_input(void)
+{
+    GPIO_PinModeSet(DHT_PORT, DHT_PIN, gpioModeInputPull, 1);
+}
+
+static bool wait_level(uint32_t level, uint32_t timeout_us)
+{
+    uint32_t start = micros();
+    while (GPIO_PinInGet(DHT_PORT, DHT_PIN) != level)
+    {
+        if ((micros() - start) > timeout_us)
+            return false;
+    }
+    return true;
+}
+
+bool DHT_Read(DHT_Data_t *data)
+{
+    uint8_t bytes[5] = {0};
+    const int max_retries = 3;
+
+    dht_release_input();
+
+    for (int attempt = 0; attempt < max_retries; ++attempt)
+    {
+        if (attempt > 0)
+        {
+            for (volatile int i = 0; i < 200000; ++i)
+                __NOP();
+        }
+
+        dht_drive_low();
+        // Use different start signal timing based on DHT type
+        if (DHT_TYPE == DHT11)
+            delay_ms(DHT11_START_SIGNAL_LOW_MS);
+        else
+            delay_ms(DHT22_START_SIGNAL_LOW_MS);
+
+        GPIO_PinModeSet(DHT_PORT, DHT_PIN, gpioModePushPull, 1);
+        for (volatile int i = 0; i < 80; ++i)
+            __NOP();
+        dht_release_input();
+
+        if (!wait_level(0, 120))
+        {
+            continue;
+        }
+        if (!wait_level(1, 120))
+        {
+            continue;
+        }
+
+        bool ok = true;
+        for (int b = 0; b < 5 && ok; ++b)
+        {
+            bytes[b] = 0;
+            for (int bit = 0; bit < 8; ++bit)
+            {
+                if (!wait_level(0, 80))
+                {
+                    ok = false;
+                    break;
+                }
+                if (!wait_level(1, 120))
+                {
+                    ok = false;
+                    break;
+                }
+                uint32_t t0 = micros();
+                if (!wait_level(0, 300))
+                {
+                    ok = false;
+                    break;
+                }
+                uint32_t t_high = micros() - t0;
+                if (t_high > DHT_BIT_THRESHOLD_US)
+                    bytes[b] |= (1 << (7 - bit));
+            }
+        }
+        if (!ok)
+            continue;
+
+        // Verify checksum
+        uint8_t sum = bytes[0] + bytes[1] + bytes[2] + bytes[3];
+        if (sum != bytes[4])
+            continue;
+
+        // Parse data based on DHT type
+        if (DHT_TYPE == DHT11)
+        {
+            // DHT11 format: integer and decimal parts are separate bytes
+            data->humidity_int = bytes[0];
+            data->humidity_dec = bytes[1];
+            data->temperature_int = bytes[2];
+            data->temperature_dec = bytes[3];
+            data->checksum = bytes[4];
+        }
+        else // DHT22
+        {
+            // DHT22 format: 16-bit values with decimal scaling
+            uint16_t rawHumidity = (bytes[0] << 8) | bytes[1];
+            uint16_t rawTemp = (bytes[2] << 8) | bytes[3];
+
+            // Handle negative temperatures for DHT22
+            if (rawTemp & 0x8000)
+            {
+                rawTemp &= 0x7FFF;
+                data->temperature_int = -(rawTemp / 10);
+                data->temperature_dec = rawTemp % 10;
+            }
+            else
+            {
+                data->temperature_int = rawTemp / 10;
+                data->temperature_dec = rawTemp % 10;
+            }
+
+            data->humidity_int = rawHumidity / 10;
+            data->humidity_dec = rawHumidity % 10;
+            data->checksum = bytes[4];
+        }
+
+        return true;
+    }
+    return false;
+}
+
+void DHT_Print(const DHT_Data_t *data)
+{
+    printf("Humidity: %d.%d%%\r\n", data->humidity_int, data->humidity_dec);
+    printf("Temperature: %d.%dC\r\n", data->temperature_int, data->temperature_dec);
+}
+
+// Arduino-style API implementations
+float DHT_ReadHumidity(void)
+{
+    DHT_Data_t data;
+    if (DHT_Read(&data))
+    {
+        return (float)data.humidity_int + (data.humidity_dec / 10.0f);
+    }
+    return -1.0f; // error
+}
+
+float DHT_ReadTemperature(void)
+{
+    DHT_Data_t data;
+    if (DHT_Read(&data))
+    {
+        return (float)data.temperature_int + (data.temperature_dec / 10.0f);
+    }
+    return -100.0f; // error
+}
+
+float DHT_ReadTemperatureF(void)
+{
+    float c = DHT_ReadTemperature();
+    if (c > -99.0f)
+    {
+        return c * 1.8f + 32.0f;
+    }
+    return -100.0f; // error
+}

--- a/hardware/driver/modbus/README.md
+++ b/hardware/driver/modbus/README.md
@@ -1,0 +1,407 @@
+# ModbusMaster RTU Driver for Silicon Labs SDK
+
+A professional Modbus RTU master driver for Silicon Labs SDK with pin tool integration, automatic debug control, and comprehensive statistics tracking.
+
+## 🚀 Features
+
+- **Pin Tool Integration**: Configure DE/RE pins and settings via GUI
+- **Automatic Debug Control**: Enable/disable debug output through configuration wizard
+- **Statistics Tracking**: Monitor communication performance and efficiency  
+- **RS485 Support**: Full DE/RE pin control for half-duplex communication
+- **Error Handling**: Comprehensive error detection (timeout, CRC, response validation)
+- **Float Decoding**: Built-in support for IEEE 754 float register pairs
+- **Multiple Register Types**: Support for holding registers (0x03) and input registers (0x04)
+
+## 📁 File Structure
+
+```
+hardware/driver/modbus/
+├── inc/modbusmaster.h                 # API header with function declarations
+├── src/modbusmaster.c                 # Driver implementation
+├── config/sl_modbusmaster_config.h    # Pin Tool configuration template
+├── test/modbus_config_test.c          # Configuration test example
+├── README.md                          # This documentation
+└── ../component/modbus_driver.slcc    # Silicon Labs component definition
+```
+
+## 🔧 Installation & Setup
+
+### Step 1: Add Component to Project
+
+1. Open **Simplicity Studio** and your project
+2. Go to **Software Components**
+3. Search for **"ModbusMaster RTU"** or **"modbus"**
+4. Install the **"ModbusMaster RTU - RS485 Communication"** component
+
+### Step 2: Configure Pin Tool
+
+1. Open **Pin Tool** in your project
+2. Navigate to **Peripherals** → **ModbusMaster**
+3. Configure the following settings:
+
+#### GPIO Configuration
+- **DE/RE Port**: Select GPIO port (e.g., `gpioPortD`)
+- **DE/RE Pin**: Select pin number (e.g., `2` for PD02)
+
+#### Communication Settings
+- **Timeout**: Response timeout in milliseconds (default: 1000ms)
+- **Guard Time**: Inter-frame delay in milliseconds (default: 5ms)
+- **Debug Enable**: Check to enable debug output (default: enabled)
+
+### Step 3: Configure UART/EUSART
+
+Ensure your project has a UART/EUSART instance configured for RS485 communication:
+
+1. **Pin Tool** → **Peripherals** → **EUSART/UART**
+2. Configure TX/RX pins for your RS485 transceiver
+3. Set baud rate (typically 9600, 19200, or 38400 for Modbus)
+
+## 📝 API Reference
+
+### Initialization Functions
+
+```c
+void ModbusMaster_begin(uint8_t slave_id);
+void ModbusMaster_setStream(sl_iostream_t *stream);
+void ModbusMaster_setDebug(uint8_t enable);
+```
+
+### Communication Functions
+
+```c
+bool ModbusMaster_readHoldingRegisters(uint16_t address, uint16_t quantity);
+bool ModbusMaster_readInputRegisters(uint16_t address, uint16_t quantity);
+uint16_t ModbusMaster_getResponseBuffer(uint16_t index);
+uint8_t ModbusMaster_getLastError();
+```
+
+### Statistics Functions
+
+```c
+uint32_t ModbusMaster_getTotalTransactions(void);
+uint32_t ModbusMaster_getTotalBytesSent(void);
+uint32_t ModbusMaster_getTotalBytesReceived(void);
+void ModbusMaster_resetStatistics(void);
+```
+
+## 💡 Usage Example
+
+### Basic Setup
+
+```c
+#include "modbusmaster.h"
+#include "sl_iostream_handles.h"
+
+void app_init(void) {
+    // Set up iostream for ModbusMaster
+    ModbusMaster_setStream(sl_iostream_mikroe_handle);
+    
+    // Initialize ModbusMaster (automatic pin and debug setup)
+    ModbusMaster_begin(1);  // Slave address 1
+    
+    printf("ModbusMaster initialized!\n");
+}
+```
+
+### Reading Sensors
+
+```c
+void read_sensor_data(void) {
+    // Read voltage from holding register 140 (2 registers for float)
+    if (ModbusMaster_readHoldingRegisters(140, 2)) {
+        // Decode IEEE 754 float from register pair
+        uint16_t reg0 = ModbusMaster_getResponseBuffer(0);
+        uint16_t reg1 = ModbusMaster_getResponseBuffer(1);
+        
+        uint32_t u = ((uint32_t)reg1 << 16) | reg0;
+        float voltage;
+        memcpy(&voltage, &u, sizeof(voltage));
+        
+        printf("Voltage: %.2f V\n", voltage);
+    } else {
+        printf("Failed to read voltage: Error %d\n", ModbusMaster_getLastError());
+    }
+}
+```
+
+### Error Handling
+
+```c
+void handle_modbus_errors(uint8_t error) {
+    switch (error) {
+        case 1: printf("Timeout error\n"); break;
+        case 2: printf("Response too short\n"); break;
+        case 3: printf("CRC error\n"); break;
+        case 4: printf("Slave/function mismatch\n"); break;
+        default: printf("Unknown error: %d\n", error); break;
+    }
+}
+```
+
+## 📊 Statistics Monitoring
+
+```c
+void display_communication_stats(void) {
+    printf("=== Communication Statistics ===\n");
+    printf("Total Transactions: %lu\n", ModbusMaster_getTotalTransactions());
+    printf("Total Bytes Sent: %lu\n", ModbusMaster_getTotalBytesSent());
+    printf("Total Bytes Received: %lu\n", ModbusMaster_getTotalBytesReceived());
+    
+    // Calculate efficiency
+    uint32_t total = ModbusMaster_getTotalBytesSent() + ModbusMaster_getTotalBytesReceived();
+    if (total > 0) {
+        float efficiency = (float)(ModbusMaster_getTotalBytesReceived() * 100) / total;
+        printf("Communication Efficiency: %.1f%%\n", efficiency);
+    }
+}
+```
+
+## 🔍 Debug Output
+
+When debug is enabled via Pin Tool configuration, the driver provides detailed logging:
+
+```
+[ModbusMaster] Debug ENABLED via pin tool (SL_MODBUSMASTER_DEBUG_ENABLE=1)
+[ModbusMaster] Begin: Slave ID=1
+[ModbusMaster] DE/RE pin configured: Port=3, Pin=2
+[ModbusMaster] readHoldingRegisters: addr=140, qty=2
+[ModbusMaster] TX: 01 03 00 8C 00 02 05 F8
+[ModbusMaster] RX: 01 03 04 43 65 33 33 7E 4F (9 bytes)
+[ModbusMaster] CRC OK, transaction successful
+```
+
+## ⚡ Complete Application Example
+
+<details>
+<summary>Click to expand full app.c example for energy meter reading</summary>
+
+```c
+#include "sl_iostream.h"
+#include "sl_iostream_handles.h"
+#include "sl_iostream_init_eusart_instances.h"
+#include "sl_iostream_uart.h"
+#include "modbusmaster.h"
+#include <stdio.h>
+#include <string.h>
+#include "em_gpio.h"
+#include "sl_sleeptimer.h"
+
+static float modbus_decode_float(uint16_t reg0, uint16_t reg1)
+{
+  // Device sends [reg0][reg1] but float is word-swapped -> [reg1][reg0]
+  uint32_t u = ((uint32_t)reg1 << 16) | reg0;
+  float f;
+  memcpy(&f, &u, sizeof(f));
+  return f;
+}
+
+void app_task(void *args)
+{
+  (void)args;
+  printf("App started\n");
+
+  // ✅ REMOVE THIS - PIN CONTROL IS NOW HANDLED BY THE DRIVER
+  // GPIO_PinModeSet(gpioPortD, 2, gpioModePushPull, 0); // Not needed anymore!
+  // printf("GPIO PD02 (PWM) configured as output\n");
+
+  // Set up ModbusMaster to use Mikroe EUSART
+  sl_iostream_uart_set_read_block(sl_iostream_uart_mikroe_handle, false);
+  ModbusMaster_setStream(sl_iostream_mikroe_handle);
+
+  // ⭐ ModbusMaster_begin() now automatically:
+  // - Configures the DE/RE pin (PD02) from pin tool settings
+  // - Initializes statistics tracking
+  // - Sets debug mode based on pin tool configuration
+  ModbusMaster_begin(1);    // slave address 1
+
+  // 🆕 OPTIONAL: Enable debug output (if not enabled via pin tool)
+  // ModbusMaster_setDebug(1);  // Enable verbose debug logging
+
+  printf("ModbusMaster initialized with enhanced features\n");
+
+  struct
+  {
+    uint16_t address;
+    const char *label;
+    const char *unit;
+  } sensors[] = {
+      {140, "Voltage", "V"},
+      {148, "Current", "A"},
+      {156, "Frequency", "Hz"},
+      {100, "Power", "W"},
+      {158, "Energy", "kWh"},
+      {116, "PF", ""},
+  };
+
+  uint32_t cycle_count = 0;
+
+  while (1)
+  {
+    cycle_count++;
+    printf("\n=== Reading Cycle #%lu ===\n", (unsigned long)cycle_count);
+
+    for (unsigned int i = 0; i < sizeof(sensors) / sizeof(sensors[0]); i++)
+    {
+      bool success = ModbusMaster_readHoldingRegisters(sensors[i].address, 2);
+      if (success)
+      {
+        float value = modbus_decode_float(
+            ModbusMaster_getResponseBuffer(0),
+            ModbusMaster_getResponseBuffer(1));
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%s : %.2f %s\r\n",
+                 sensors[i].label, value, sensors[i].unit);
+        sl_iostream_write(sl_iostream_vcom_handle, buf, strlen(buf));
+      }
+      else
+      {
+        uint8_t err = ModbusMaster_getLastError();
+        char err_msg[64];
+        switch (err)
+        {
+        case 1:
+          snprintf(err_msg, sizeof(err_msg), "ERROR: %s read timeout\r\n", sensors[i].label);
+          break;
+        case 2:
+          snprintf(err_msg, sizeof(err_msg), "ERROR: %s response too short\r\n", sensors[i].label);
+          break;
+        case 3:
+          snprintf(err_msg, sizeof(err_msg), "ERROR: %s CRC error\r\n", sensors[i].label);
+          break;
+        case 4:
+          snprintf(err_msg, sizeof(err_msg), "ERROR: %s slave/function mismatch\r\n", sensors[i].label);
+          break;
+        default:
+          snprintf(err_msg, sizeof(err_msg), "ERROR: %s unknown error (%d)\r\n", sensors[i].label, err);
+          break;
+        }
+        sl_iostream_write(sl_iostream_vcom_handle, err_msg, strlen(err_msg));
+      }
+
+      // Small delay between sensor reads
+      sl_sleeptimer_delay_millisecond(100);
+    }
+
+    // 🆕 DISPLAY COMMUNICATION STATISTICS
+    printf("\n=== Communication Statistics ===\n");
+    printf("Total Transactions: %lu\n", (unsigned long)ModbusMaster_getTotalTransactions());
+    printf("Total Bytes Sent: %lu\n", (unsigned long)ModbusMaster_getTotalBytesSent());
+    printf("Total Bytes Received: %lu\n", (unsigned long)ModbusMaster_getTotalBytesReceived());
+
+    // Calculate efficiency
+    uint32_t total_bytes = ModbusMaster_getTotalBytesSent() + ModbusMaster_getTotalBytesReceived();
+    if (total_bytes > 0) {
+      printf("Communication Efficiency: %.1f%% successful\n",
+             (float)(ModbusMaster_getTotalBytesReceived() * 100) / total_bytes);
+    }
+
+    sl_iostream_write(sl_iostream_vcom_handle, "==============..........================\r\n\r\n", 42);
+
+    // 🆕 OPTIONAL: Reset statistics every 10 cycles to prevent overflow
+    if (cycle_count % 10 == 0) {
+      printf("Resetting statistics after 10 cycles...\n");
+      ModbusMaster_resetStatistics();
+    }
+
+    sl_sleeptimer_delay_millisecond(10000);
+  }
+}
+```
+
+</details>
+
+## 🛠️ Configuration Options
+
+### Pin Tool Configuration Wizard
+
+The driver uses Silicon Labs Pin Tool Configuration Wizard with the following options:
+
+| Setting | Description | Default | Range |
+|---------|-------------|---------|-------|
+| DE/RE Port | GPIO port for DE/RE control | gpioPortA | Any GPIO port |
+| DE/RE Pin | GPIO pin number | 0 | 0-15 |
+| Timeout | Response timeout | 1000ms | 100-10000ms |
+| Guard Time | Inter-frame delay | 5ms | 1-100ms |
+| Debug Enable | Enable debug output | Yes | Yes/No |
+
+### Configuration File Structure
+
+```c
+// sl_modbusmaster_config.h
+#define SL_MODBUSMASTER_DE_PORT       gpioPortD
+#define SL_MODBUSMASTER_DE_PIN        2
+#define SL_MODBUSMASTER_TIMEOUT_MS    1000
+#define SL_MODBUSMASTER_GUARD_TIME_MS 5
+#define SL_MODBUSMASTER_DEBUG_ENABLE  1
+```
+
+## 🔧 Troubleshooting
+
+### Common Issues
+
+#### 1. Communication Failures (Low Efficiency < 80%)
+- **Check RS485 wiring**: Ensure A/B lines are correctly connected
+- **Verify termination**: Add 120Ω resistors at both ends of RS485 bus  
+- **Check baud rate**: Ensure master and slave have matching baud rates
+- **Increase timeout**: Try longer timeout values for slow devices
+
+#### 2. CRC Errors
+- **Electrical noise**: Check for proper shielding and grounding
+- **Baud rate mismatch**: Verify communication speed settings
+- **Cable quality**: Use proper RS485 cable (twisted pair)
+
+#### 3. No Response (Timeout Errors)
+- **Slave address**: Verify the slave device address is correct
+- **DE/RE timing**: Check if guard time needs to be increased
+- **Physical connection**: Verify TX/RX and DE/RE pin connections
+
+#### 4. Compilation Errors
+- **Missing includes**: Ensure all required headers are included
+- **Component not installed**: Verify ModbusMaster component is added to project
+- **Pin Tool configuration**: Ensure Pin Tool has been configured and generated
+
+### Debug Tips
+
+1. **Enable Debug Output**: Set `SL_MODBUSMASTER_DEBUG_ENABLE=1` in Pin Tool
+2. **Monitor Statistics**: Use statistics functions to track communication health
+3. **Check Error Codes**: Use `ModbusMaster_getLastError()` for specific error information
+4. **Verify Frame Format**: Debug output shows exact TX/RX bytes for analysis
+
+## 📈 Performance Guidelines
+
+### Optimal Settings
+- **Baud Rate**: 9600-38400 for most industrial applications
+- **Timeout**: 1000-2000ms for reliable communication  
+- **Guard Time**: 5-10ms between transactions
+- **Efficiency Target**: >95% for good communication quality
+
+### Memory Usage
+- **RAM Usage**: ~100 bytes for buffers and statistics
+- **Flash Usage**: ~2KB for driver code
+- **Stack Usage**: Minimal (<50 bytes per function call)
+
+## 📚 Additional Resources
+
+- **Modbus RTU Specification**: [Modbus Organization](https://modbus.org/)
+- **Silicon Labs SDK Documentation**: Available in Simplicity Studio
+- **RS485 Design Guide**: Check Silicon Labs application notes
+- **Pin Tool User Guide**: Simplicity Studio documentation
+
+## 🤝 Support
+
+For issues and questions:
+1. Check the troubleshooting section above
+2. Verify your Pin Tool configuration
+3. Enable debug output for detailed diagnostics
+4. Check Silicon Labs community forums
+
+---
+
+**Version**: 1.0  
+**Compatibility**: Silicon Labs SDK v5.x  
+**License**: Silicon Labs License Agreement
+
+
+
+
+https://stagb.in/emv1.1

--- a/hardware/driver/modbus/README.md
+++ b/hardware/driver/modbus/README.md
@@ -6,7 +6,6 @@ A professional Modbus RTU master driver for Silicon Labs SDK with pin tool integ
 
 - **Pin Tool Integration**: Configure DE/RE pins and settings via GUI
 - **Automatic Debug Control**: Enable/disable debug output through configuration wizard
-- **Statistics Tracking**: Monitor communication performance and efficiency  
 - **RS485 Support**: Full DE/RE pin control for half-duplex communication
 - **Error Handling**: Comprehensive error detection (timeout, CRC, response validation)
 - **Float Decoding**: Built-in support for IEEE 754 float register pairs
@@ -75,15 +74,6 @@ uint16_t ModbusMaster_getResponseBuffer(uint16_t index);
 uint8_t ModbusMaster_getLastError();
 ```
 
-### Statistics Functions
-
-```c
-uint32_t ModbusMaster_getTotalTransactions(void);
-uint32_t ModbusMaster_getTotalBytesSent(void);
-uint32_t ModbusMaster_getTotalBytesReceived(void);
-void ModbusMaster_resetStatistics(void);
-```
-
 ## 💡 Usage Example
 
 ### Basic Setup
@@ -138,20 +128,24 @@ void handle_modbus_errors(uint8_t error) {
 }
 ```
 
-## 📊 Statistics Monitoring
+## 📊 Communication Monitoring
 
 ```c
-void display_communication_stats(void) {
-    printf("=== Communication Statistics ===\n");
-    printf("Total Transactions: %lu\n", ModbusMaster_getTotalTransactions());
-    printf("Total Bytes Sent: %lu\n", ModbusMaster_getTotalBytesSent());
-    printf("Total Bytes Received: %lu\n", ModbusMaster_getTotalBytesReceived());
+void display_communication_info(void) {
+    printf("=== Communication Status ===\n");
+    uint8_t last_error = ModbusMaster_getLastError();
     
-    // Calculate efficiency
-    uint32_t total = ModbusMaster_getTotalBytesSent() + ModbusMaster_getTotalBytesReceived();
-    if (total > 0) {
-        float efficiency = (float)(ModbusMaster_getTotalBytesReceived() * 100) / total;
-        printf("Communication Efficiency: %.1f%%\n", efficiency);
+    if (last_error == 0) {
+        printf("Last Transaction: SUCCESS\n");
+    } else {
+        printf("Last Transaction: ERROR (%d)\n", last_error);
+        switch (last_error) {
+            case 1: printf("  - Timeout error\n"); break;
+            case 2: printf("  - Response too short\n"); break;
+            case 3: printf("  - CRC error\n"); break;
+            case 4: printf("  - Slave/function mismatch\n"); break;
+            default: printf("  - Unknown error\n"); break;
+        }
     }
 }
 ```
@@ -163,8 +157,8 @@ When debug is enabled via Pin Tool configuration, the driver provides detailed l
 ```
 [ModbusMaster] Debug ENABLED via pin tool (SL_MODBUSMASTER_DEBUG_ENABLE=1)
 [ModbusMaster] Begin: Slave ID=1
-[ModbusMaster] DE/RE pin configured: Port=3, Pin=2
-[ModbusMaster] readHoldingRegisters: addr=140, qty=2
+[ModbusMaster] DE/RE pin configured: Port=C, Pin=1
+[ModbusMaster] reg=140, count=2
 [ModbusMaster] TX: 01 03 00 8C 00 02 05 F8
 [ModbusMaster] RX: 01 03 04 43 65 33 33 7E 4F (9 bytes)
 [ModbusMaster] CRC OK, transaction successful
@@ -208,16 +202,12 @@ void app_task(void *args)
   sl_iostream_uart_set_read_block(sl_iostream_uart_mikroe_handle, false);
   ModbusMaster_setStream(sl_iostream_mikroe_handle);
 
-  // ⭐ ModbusMaster_begin() now automatically:
-  // - Configures the DE/RE pin (PD02) from pin tool settings
-  // - Initializes statistics tracking
+  // ModbusMaster_begin() automatically:
+  // - Configures the DE/RE pin from pin tool settings
   // - Sets debug mode based on pin tool configuration
   ModbusMaster_begin(1);    // slave address 1
 
-  // 🆕 OPTIONAL: Enable debug output (if not enabled via pin tool)
-  // ModbusMaster_setDebug(1);  // Enable verbose debug logging
-
-  printf("ModbusMaster initialized with enhanced features\n");
+  printf("ModbusMaster initialized with pin tool configuration\n");
 
   struct
   {
@@ -282,26 +272,7 @@ void app_task(void *args)
       sl_sleeptimer_delay_millisecond(100);
     }
 
-    // 🆕 DISPLAY COMMUNICATION STATISTICS
-    printf("\n=== Communication Statistics ===\n");
-    printf("Total Transactions: %lu\n", (unsigned long)ModbusMaster_getTotalTransactions());
-    printf("Total Bytes Sent: %lu\n", (unsigned long)ModbusMaster_getTotalBytesSent());
-    printf("Total Bytes Received: %lu\n", (unsigned long)ModbusMaster_getTotalBytesReceived());
-
-    // Calculate efficiency
-    uint32_t total_bytes = ModbusMaster_getTotalBytesSent() + ModbusMaster_getTotalBytesReceived();
-    if (total_bytes > 0) {
-      printf("Communication Efficiency: %.1f%% successful\n",
-             (float)(ModbusMaster_getTotalBytesReceived() * 100) / total_bytes);
-    }
-
     sl_iostream_write(sl_iostream_vcom_handle, "==============..........================\r\n\r\n", 42);
-
-    // 🆕 OPTIONAL: Reset statistics every 10 cycles to prevent overflow
-    if (cycle_count % 10 == 0) {
-      printf("Resetting statistics after 10 cycles...\n");
-      ModbusMaster_resetStatistics();
-    }
 
     sl_sleeptimer_delay_millisecond(10000);
   }
@@ -318,28 +289,28 @@ The driver uses Silicon Labs Pin Tool Configuration Wizard with the following op
 
 | Setting | Description | Default | Range |
 |---------|-------------|---------|-------|
-| DE/RE Port | GPIO port for DE/RE control | gpioPortA | Any GPIO port |
-| DE/RE Pin | GPIO pin number | 0 | 0-15 |
+| DE/RE Port | GPIO port for DE/RE control | gpioPortC | Any GPIO port |
+| DE/RE Pin | GPIO pin number | 1 | 0-15 |
 | Timeout | Response timeout | 1000ms | 100-10000ms |
-| Guard Time | Inter-frame delay | 5ms | 1-100ms |
-| Debug Enable | Enable debug output | Yes | Yes/No |
+| Guard Time | Inter-frame delay | 10ms | 1-100ms |
+| Debug Enable | Enable debug output | No | Yes/No |
 
 ### Configuration File Structure
 
 ```c
 // sl_modbusmaster_config.h
-#define SL_MODBUSMASTER_DE_PORT       gpioPortD
-#define SL_MODBUSMASTER_DE_PIN        2
+#define SL_MODBUSMASTER_DE_RE_PORT    SL_GPIO_PORT_C
+#define SL_MODBUSMASTER_DE_RE_PIN     1
 #define SL_MODBUSMASTER_TIMEOUT_MS    1000
-#define SL_MODBUSMASTER_GUARD_TIME_MS 5
-#define SL_MODBUSMASTER_DEBUG_ENABLE  1
+#define SL_MODBUSMASTER_GUARD_TIME_MS 10
+#define SL_MODBUSMASTER_DEBUG_ENABLE  0
 ```
 
 ## 🔧 Troubleshooting
 
 ### Common Issues
 
-#### 1. Communication Failures (Low Efficiency < 80%)
+#### 1. Communication Failures
 - **Check RS485 wiring**: Ensure A/B lines are correctly connected
 - **Verify termination**: Add 120Ω resistors at both ends of RS485 bus  
 - **Check baud rate**: Ensure master and slave have matching baud rates
@@ -363,20 +334,20 @@ The driver uses Silicon Labs Pin Tool Configuration Wizard with the following op
 ### Debug Tips
 
 1. **Enable Debug Output**: Set `SL_MODBUSMASTER_DEBUG_ENABLE=1` in Pin Tool
-2. **Monitor Statistics**: Use statistics functions to track communication health
-3. **Check Error Codes**: Use `ModbusMaster_getLastError()` for specific error information
-4. **Verify Frame Format**: Debug output shows exact TX/RX bytes for analysis
+2. **Check Error Codes**: Use `ModbusMaster_getLastError()` for specific error information
+3. **Verify Frame Format**: Debug output shows exact TX/RX bytes for analysis
+4. **Test with Simple Reads**: Start with single register reads to verify basic communication
 
 ## 📈 Performance Guidelines
 
 ### Optimal Settings
 - **Baud Rate**: 9600-38400 for most industrial applications
 - **Timeout**: 1000-2000ms for reliable communication  
-- **Guard Time**: 5-10ms between transactions
-- **Efficiency Target**: >95% for good communication quality
+- **Guard Time**: 10-20ms between transactions
+- **Error Handling**: Always check return values and error codes
 
 ### Memory Usage
-- **RAM Usage**: ~100 bytes for buffers and statistics
+- **RAM Usage**: ~50 bytes for buffers and state variables
 - **Flash Usage**: ~2KB for driver code
 - **Stack Usage**: Minimal (<50 bytes per function call)
 
@@ -384,8 +355,6 @@ The driver uses Silicon Labs Pin Tool Configuration Wizard with the following op
 
 - **Modbus RTU Specification**: [Modbus Organization](https://modbus.org/)
 - **Silicon Labs SDK Documentation**: Available in Simplicity Studio
-- **RS485 Design Guide**: Check Silicon Labs application notes
-- **Pin Tool User Guide**: Simplicity Studio documentation
 
 ## 🤝 Support
 
@@ -397,11 +366,7 @@ For issues and questions:
 
 ---
 
-**Version**: 1.0  
+**Version**: 1.0.1  
 **Compatibility**: Silicon Labs SDK v5.x  
-**License**: Silicon Labs License Agreement
+**Last Updated**: September 2025
 
-
-
-
-https://stagb.in/emv1.1

--- a/hardware/driver/modbus/config/sl_modbusmaster_config.h
+++ b/hardware/driver/modbus/config/sl_modbusmaster_config.h
@@ -1,0 +1,36 @@
+/***************************************************************************/ /**
+                                                                               * @file sl_modbusmaster_config.h
+                                                                               * @brief ModbusMaster Driver Configuration
+                                                                               ******************************************************************************/
+#ifndef SL_MODBUSMASTER_CONFIG_H
+#define SL_MODBUSMASTER_CONFIG_H
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> ModbusMaster Configuration
+
+// <o SL_MODBUSMASTER_TIMEOUT_MS> Modbus Timeout (ms) <1-10000>
+// <i> Default: 1000
+#define SL_MODBUSMASTER_TIMEOUT_MS 1000
+
+// <o SL_MODBUSMASTER_GUARD_TIME_MS> Guard Time (ms) <0-1000>
+// <i> Default: 10
+#define SL_MODBUSMASTER_GUARD_TIME_MS 2
+
+// <q SL_MODBUSMASTER_DEBUG_ENABLE> Enable Debug Output
+// <i> Default: 0
+#define SL_MODBUSMASTER_DEBUG_ENABLE 0
+
+// </h>
+
+// <<< end of configuration section >>>
+
+// <<< sl:start pin_tool >>>
+// <gpio> SL_MODBUSMASTER_DE_RE
+// $[GPIO_SL_MODBUSMASTER_DE_RE]
+#define SL_MODBUSMASTER_DE_RE_PORT SL_GPIO_PORT_C
+#define SL_MODBUSMASTER_DE_RE_PIN 1
+// [GPIO_SL_MODBUSMASTER_DE_RE]$
+// <<< sl:end pin_tool >>>
+
+#endif // SL_MODBUSMASTER_CONFIG_H

--- a/hardware/driver/modbus/inc/modbusmaster.h
+++ b/hardware/driver/modbus/inc/modbusmaster.h
@@ -1,0 +1,36 @@
+#ifndef MODBUSMASTER_H
+#define MODBUSMASTER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "sl_modbusmaster_config.h"
+
+#define MODBUS_MAX_BUFFER 64
+
+// Runtime debug flag for Modbus logs
+extern int modbus_debug_flag;
+void ModbusMaster_setDebug(int flag);
+
+// User must call this once at startup
+void ModbusMaster_begin(uint8_t slave_id);
+
+// Buffer management functions
+uint16_t ModbusMaster_getResponseBuffer(uint8_t index);
+void ModbusMaster_clearResponseBuffer(void);
+uint8_t ModbusMaster_setTransmitBuffer(uint8_t index, uint16_t value);
+void ModbusMaster_clearTransmitBuffer(void);
+
+// Modbus function codes
+bool ModbusMaster_readHoldingRegisters(uint16_t reg, uint16_t count);
+bool ModbusMaster_readInputRegisters(uint16_t reg, uint16_t count);
+
+// Set RS485 DE/RE control pin (user must implement this for their board)
+void ModbusMaster_setTransmit(bool enable);
+
+// Set EUSART handle (user must provide sl_iostream_t* for their instance)
+void ModbusMaster_setStream(void *stream);
+
+// Get last error code (0=success, 1=timeout, 2=short response, 3=CRC error, 4=slave/function mismatch)
+uint8_t ModbusMaster_getLastError(void);
+
+#endif // MODBUSMASTER_H

--- a/hardware/driver/modbus/src/modbusmaster.c
+++ b/hardware/driver/modbus/src/modbusmaster.c
@@ -1,0 +1,733 @@
+/*
+ * ModbusMaster RTU Driver for Silicon Labs SDK
+ * Supports reading holding registers and input registers with configurable DE/RE pin control
+ */
+#include "modbusmaster.h"
+#include <string.h>
+#include "sl_iostream.h"
+#include <stdio.h>
+#include "sl_sleeptimer.h"
+#include "em_gpio.h"
+#include "sl_status.h"
+#include "sl_modbusmaster_config.h"
+
+#define MODBUS_RTU_MAX_FRAME 256
+
+// Use configured DE/RE pin from pin tool
+#define MODBUS_DE_PORT SL_MODBUSMASTER_DE_RE_PORT
+#define MODBUS_DE_PIN SL_MODBUSMASTER_DE_RE_PIN
+
+int modbus_debug_flag = 0;
+void ModbusMaster_setDebug(int flag) { modbus_debug_flag = flag; }
+
+static uint8_t _slave_id = 1;
+static void *_stream = NULL;
+static uint8_t _last_error = 0;
+
+#define MODBUS_MAX_BUFFER 64
+static uint16_t _responseBuffer[MODBUS_MAX_BUFFER];
+static uint16_t _transmitBuffer[MODBUS_MAX_BUFFER];
+
+// Buffer management
+uint16_t ModbusMaster_getResponseBuffer(uint8_t index)
+{
+    if (index < MODBUS_MAX_BUFFER)
+        return _responseBuffer[index];
+    return 0xFFFF;
+}
+void ModbusMaster_clearResponseBuffer(void)
+{
+    for (int i = 0; i < MODBUS_MAX_BUFFER; i++)
+        _responseBuffer[i] = 0;
+}
+uint8_t ModbusMaster_setTransmitBuffer(uint8_t index, uint16_t value)
+{
+    if (index < MODBUS_MAX_BUFFER)
+    {
+        _transmitBuffer[index] = value;
+        return 0;
+    }
+    return 2;
+}
+void ModbusMaster_clearTransmitBuffer(void)
+{
+    for (int i = 0; i < MODBUS_MAX_BUFFER; i++)
+        _transmitBuffer[i] = 0;
+}
+
+// Decode Modbus 2x16-bit registers into a float (word-swapped IEEE754)
+// static float modbus_decode_float(uint16_t reg0, uint16_t reg1)
+//{
+//    uint32_t u = ((uint32_t)reg1 << 16) | reg0;
+//    float f;
+//    memcpy(&f, &u, sizeof(f));
+//    return f;
+//}
+
+void ModbusMaster_setStream(void *stream)
+{
+    _stream = stream;
+}
+
+void ModbusMaster_begin(uint8_t slave_id)
+{
+    _slave_id = slave_id;
+
+
+    // Set debug mode from pin tool configuration
+    ModbusMaster_setDebug(SL_MODBUSMASTER_DEBUG_ENABLE);
+    if (SL_MODBUSMASTER_DEBUG_ENABLE)
+    {
+        printf("[ModbusMaster] Debug ENABLED via pin tool (SL_MODBUSMASTER_DEBUG_ENABLE=%d)\n", SL_MODBUSMASTER_DEBUG_ENABLE);
+    }
+    else
+    {
+        printf("[ModbusMaster] Debug DISABLED via pin tool (SL_MODBUSMASTER_DEBUG_ENABLE=%d)\n", SL_MODBUSMASTER_DEBUG_ENABLE);
+    }
+
+    // Initialize DE/RE pin as output, default to receive mode
+    GPIO_PinModeSet(MODBUS_DE_PORT, MODBUS_DE_PIN, gpioModePushPull, 0);
+}
+
+uint8_t ModbusMaster_getLastError(void)
+{
+    return _last_error;
+}
+
+// Statistics functions
+
+
+// RS485 DE/RE control using pin tool configuration
+void ModbusMaster_setTransmit(bool enable)
+{
+    if (modbus_debug_flag)
+    {
+        printf("[RS485] Setting transmit: %s\n", enable ? "TRUE" : "FALSE");
+    }
+    if (enable)
+    {
+        GPIO_PinOutSet(MODBUS_DE_PORT, MODBUS_DE_PIN); // Transmit
+    }
+    else
+    {
+        GPIO_PinOutClear(MODBUS_DE_PORT, MODBUS_DE_PIN); // Receive
+    }
+}
+
+// CRC16 calculation (Modbus RTU)
+static uint16_t _crc16(const uint8_t *buf, uint16_t len)
+{
+    uint16_t crc = 0xFFFF;
+    for (uint16_t pos = 0; pos < len; pos++)
+    {
+        crc ^= (uint16_t)buf[pos];
+        for (int i = 0; i < 8; i++)
+        {
+            if (crc & 0x0001)
+            {
+                crc >>= 1;
+                crc ^= 0xA001;
+            }
+            else
+            {
+                crc >>= 1;
+            }
+        }
+    }
+    return crc;
+}
+
+// Decode Modbus 2x16-bit registers into a float (word-swapped IEEE754)
+static float _modbus_decode_float(uint16_t reg0, uint16_t reg1)
+{
+    uint32_t u = ((uint32_t)reg1 << 16) | reg0; // swap words
+    float f;
+    memcpy(&f, &u, sizeof(f));
+    return f;
+}
+
+// Send and receive a Modbus RTU frame (function 0x03 only)
+// Helper: check elapsed ms using sleeptimer
+static uint32_t _elapsed_ms(uint32_t start_tick)
+{
+    uint32_t now = sl_sleeptimer_get_tick_count();
+    uint32_t elapsed_ticks = now - start_tick; // safe wraparound
+    return sl_sleeptimer_tick_to_ms(elapsed_ticks);
+}
+
+// Send and receive a Modbus RTU frame (function 0x03 only)
+bool ModbusMaster_readHoldingRegisters(uint16_t reg, uint16_t count)
+{
+    ModbusMaster_clearResponseBuffer();
+    extern void *sl_iostream_vcom_handle;
+    char dbg_buf[128];
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf),
+                 "[ModbusMaster] reg=%d, count=%d\n", reg, count);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+
+    if (!_stream)
+    {
+        _last_error = 2;
+        return false;
+    }
+
+    // Build request frame
+    uint8_t req[8];
+    req[0] = _slave_id;
+    req[1] = 0x03;
+    req[2] = reg >> 8;
+    req[3] = reg & 0xFF;
+    req[4] = count >> 8;
+    req[5] = count & 0xFF;
+    uint16_t crc = _crc16(req, 6);
+    req[6] = crc & 0xFF;
+    req[7] = crc >> 8;
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Sending request: ");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        for (int i = 0; i < 8; ++i)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "%02X ", req[i]);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+        snprintf(dbg_buf, sizeof(dbg_buf), "\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+
+    // Drain any stale RX bytes before sending (avoid echo/old data)
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Flushing stale RX before TX...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    {
+        uint8_t dump;
+        size_t n = 0;
+        while (sl_iostream_read(_stream, &dump, 1, &n) == SL_STATUS_OK && n == 1)
+        {
+            // discard
+        }
+    }
+
+    // Send request
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Setting transmit mode...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    ModbusMaster_setTransmit(true);
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Writing to stream...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    sl_iostream_write(_stream, req, 8);
+    for (volatile int i = 0; i < 50000; i++)
+        ; // short delay
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Setting receive mode...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    ModbusMaster_setTransmit(false);
+    // Guard time after DE low (~2 char times at 9600 bps)
+    sl_sleeptimer_delay_millisecond(SL_MODBUSMASTER_GUARD_TIME_MS);
+
+    // Receive loop with timeout
+    uint8_t resp[MODBUS_RTU_MAX_FRAME];
+    uint16_t resp_len = 0;
+    bool got_response = false;
+    int expected_len = 0;
+    uint32_t timeout_ms = SL_MODBUSMASTER_TIMEOUT_MS;
+    uint32_t start = sl_sleeptimer_get_tick_count();
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Receive mode set, waiting...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Waiting for response...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    while (resp_len < MODBUS_RTU_MAX_FRAME && _elapsed_ms(start) < timeout_ms)
+    {
+        uint8_t c;
+        size_t bytes_read = 0;
+        sl_status_t st = sl_iostream_read(_stream, &c, 1, &bytes_read);
+
+        if (st == SL_STATUS_OK && bytes_read == 1)
+        {
+            // Enforce Modbus RTU header to avoid matching our own echo
+            if (resp_len == 0)
+            {
+                if (c != _slave_id)
+                {
+                    // ignore junk byte
+                }
+                else
+                {
+                    resp[resp_len++] = c;
+                    got_response = true;
+                }
+            }
+            else if (resp_len == 1)
+            {
+                if (c != 0x03)
+                {
+                    // not the expected function, resync
+                    resp_len = 0;
+                }
+                else
+                {
+                    resp[resp_len++] = c;
+                    got_response = true;
+                    if (modbus_debug_flag)
+                    {
+                        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Got byte %d: 0x%02X\n", resp_len, c);
+                        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                    }
+                }
+            }
+            else if (resp_len == 2)
+            {
+                uint8_t expected_bytes = (uint8_t)(count * 2);
+                if (c != expected_bytes)
+                {
+                    // third byte in a valid response is byte count; if not matching, resync
+                    resp_len = 0;
+                }
+                else
+                {
+                    resp[resp_len++] = c;
+                    got_response = true;
+                    expected_len = c + 5; // addr + func + bytecount + data + CRC(2)
+                    if (modbus_debug_flag)
+                    {
+                        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Got byte %d: 0x%02X\n", resp_len, c);
+                        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Expected total bytes: %d\n", expected_len);
+                        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                    }
+                }
+            }
+            else
+            {
+                // normal payload/CRC accumulation
+                resp[resp_len++] = c;
+                got_response = true;
+                if (modbus_debug_flag)
+                {
+                    snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Got byte %d: 0x%02X\n", resp_len, c);
+                    sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                }
+                if (expected_len > 0 && resp_len >= expected_len)
+                {
+                    if (modbus_debug_flag)
+                    {
+                        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Full response received (%d bytes)\n", resp_len);
+                        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                    }
+                    break;
+                }
+            }
+        }
+        else
+        {
+            // No data yet, small delay to prevent tight loop
+            sl_sleeptimer_delay_millisecond(SL_MODBUSMASTER_GUARD_TIME_MS);
+        }
+    }
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] LOOP END\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] === RESPONSE LOOP COMPLETE ===\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] === PRINTING RECEIVED BYTES ===\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Received bytes: ");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        for (int i = 0; i < (int)resp_len; ++i)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "%02X ", resp[i]);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+        snprintf(dbg_buf, sizeof(dbg_buf), "\n[ModbusMaster] === BYTES PRINTED ===\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+
+    if (resp_len < 5)
+    {
+        uint32_t elapsed = _elapsed_ms(start);
+        if (!got_response)
+        {
+            if (modbus_debug_flag)
+            {
+                snprintf(dbg_buf, sizeof(dbg_buf),
+                         "[ModbusMaster] ERROR: Timeout/no response (elapsed=%lu ms, resp_len=%u)\n",
+                         (unsigned long)elapsed, (unsigned)resp_len);
+                sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+            }
+            _last_error = 1; // timeout
+        }
+        else
+        {
+            if (modbus_debug_flag)
+            {
+                snprintf(dbg_buf, sizeof(dbg_buf),
+                         "[ModbusMaster] ERROR: Short/partial frame (elapsed=%lu ms, resp_len=%u)\n",
+                         (unsigned long)elapsed, (unsigned)resp_len);
+                sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+            }
+            _last_error = 2; // short frame
+        }
+        return false;
+    }
+
+    // CRC check
+    uint16_t crc_resp = resp[resp_len - 2] | (resp[resp_len - 1] << 8);
+    uint16_t crc_calc = _crc16(resp, resp_len - 2);
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] CRC received: 0x%04X, calculated: 0x%04X\n", crc_resp, crc_calc);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    if (crc_calc != crc_resp)
+    {
+        _last_error = 3;
+        if (modbus_debug_flag)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] ERROR: CRC mismatch. Calc: 0x%04X, Recv: 0x%04X\n", crc_calc, crc_resp);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+        return false;
+    }
+
+    if (resp[0] != _slave_id || resp[1] != 0x03)
+    {
+        _last_error = 4;
+        if (modbus_debug_flag)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] ERROR: Slave or function mismatch. Expected: slave=%d func=0x03, Got: slave=%d func=0x%02X\n",
+                     _slave_id, resp[0], resp[1]);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+        return false;
+    }
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Parsing %d registers:\n", count);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    for (int i = 0; i < count; i++)
+    {
+        _responseBuffer[i] = (resp[3 + 2 * i] << 8) | resp[4 + 2 * i];
+        if (modbus_debug_flag)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Register %d: 0x%04X (%d)\n", i, _responseBuffer[i], _responseBuffer[i]);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+    }
+    if (modbus_debug_flag && count == 2)
+    {
+        float value = _modbus_decode_float(_responseBuffer[0], _responseBuffer[1]);
+        int rounded = (int)(value + 0.5f);
+        snprintf(dbg_buf, sizeof(dbg_buf), ">>> Decoded float value: %.4f\n", value);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), ">>> Rounded integer value: %d\n", rounded);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    _last_error = 0;
+    return true;
+}
+
+// Send and receive a Modbus RTU frame (function 0x04: input registers)
+bool ModbusMaster_readInputRegisters(uint16_t reg, uint16_t count)
+{
+    ModbusMaster_clearResponseBuffer();
+    extern void *sl_iostream_vcom_handle;
+    char dbg_buf[128];
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf),
+                 "[ModbusMaster] reg=%d, count=%d\n", reg, count);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+
+    if (!_stream)
+    {
+        _last_error = 2;
+        return false;
+    }
+
+    // Build request
+    uint8_t req[8];
+    req[0] = _slave_id;
+    req[1] = 0x04;
+    req[2] = reg >> 8;
+    req[3] = reg & 0xFF;
+    req[4] = count >> 8;
+    req[5] = count & 0xFF;
+    uint16_t crc = _crc16(req, 6);
+    req[6] = crc & 0xFF;
+    req[7] = crc >> 8;
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Sending request: ");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        for (int i = 0; i < 8; ++i)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "%02X ", req[i]);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+        snprintf(dbg_buf, sizeof(dbg_buf), "\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+
+    // Drain any stale RX bytes before sending (avoid echo/old data)
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Flushing stale RX before TX...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    {
+        uint8_t dump;
+        size_t n = 0;
+        while (sl_iostream_read(_stream, &dump, 1, &n) == SL_STATUS_OK && n == 1)
+        {
+            // discard
+        }
+    }
+
+    // Send request
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Setting transmit mode...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    ModbusMaster_setTransmit(true);
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Writing to stream...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    sl_iostream_write(_stream, req, 8);
+
+    for (volatile int i = 0; i < 50000; i++)
+        ;
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Setting receive mode...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    ModbusMaster_setTransmit(false);
+    // Guard time after DE low (~2 char times at 9600 bps)
+    sl_sleeptimer_delay_millisecond(SL_MODBUSMASTER_GUARD_TIME_MS);
+
+    // Receive loop
+    uint8_t resp[MODBUS_RTU_MAX_FRAME];
+    uint16_t resp_len = 0;
+    bool got_response = false;
+    int expected_len = 0;
+    uint32_t timeout_ms = SL_MODBUSMASTER_TIMEOUT_MS;
+    uint32_t start = sl_sleeptimer_get_tick_count();
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Receive mode set, waiting...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Waiting for response...\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    while (resp_len < MODBUS_RTU_MAX_FRAME && _elapsed_ms(start) < timeout_ms)
+    {
+        uint8_t c;
+        size_t bytes_read = 0;
+        sl_status_t st = sl_iostream_read(_stream, &c, 1, &bytes_read);
+
+        if (st == SL_STATUS_OK && bytes_read == 1)
+        {
+            if (resp_len == 0)
+            {
+                if (c != _slave_id)
+                {
+                    // ignore junk byte
+                }
+                else
+                {
+                    resp[resp_len++] = c;
+                    got_response = true;
+                }
+            }
+            else if (resp_len == 1)
+            {
+                if (c != 0x04)
+                {
+                    resp_len = 0; // resync
+                }
+                else
+                {
+                    resp[resp_len++] = c;
+                    got_response = true;
+                    if (modbus_debug_flag)
+                    {
+                        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Got byte %d: 0x%02X\n", resp_len, c);
+                        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                    }
+                }
+            }
+            else if (resp_len == 2)
+            {
+                uint8_t expected_bytes = (uint8_t)(count * 2);
+                if (c != expected_bytes)
+                {
+                    resp_len = 0; // resync
+                }
+                else
+                {
+                    resp[resp_len++] = c;
+                    got_response = true;
+                    expected_len = c + 5;
+                    if (modbus_debug_flag)
+                    {
+                        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Got byte %d: 0x%02X\n", resp_len, c);
+                        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Expected total bytes: %d\n", expected_len);
+                        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                    }
+                }
+            }
+            else
+            {
+                resp[resp_len++] = c;
+                got_response = true;
+                if (modbus_debug_flag)
+                {
+                    snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Got byte %d: 0x%02X\n", resp_len, c);
+                    sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                }
+                if (expected_len > 0 && resp_len >= expected_len)
+                {
+                    if (modbus_debug_flag)
+                    {
+                        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Full response received (%d bytes)\n", resp_len);
+                        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+                    }
+                    break;
+                }
+            }
+        }
+        else
+        {
+            // No data yet, small delay to prevent tight loop
+            sl_sleeptimer_delay_millisecond(SL_MODBUSMASTER_GUARD_TIME_MS);
+        }
+    }
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] LOOP END\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] === RESPONSE LOOP COMPLETE ===\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] === PRINTING RECEIVED BYTES ===\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Received bytes: ");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        for (int i = 0; i < (int)resp_len; ++i)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "%02X ", resp[i]);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+        snprintf(dbg_buf, sizeof(dbg_buf), "\n[ModbusMaster] === BYTES PRINTED ===\n");
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+
+    if (resp_len < 5)
+    {
+        uint32_t elapsed = _elapsed_ms(start);
+        if (!got_response)
+        {
+            if (modbus_debug_flag)
+            {
+                snprintf(dbg_buf, sizeof(dbg_buf),
+                         "[ModbusMaster] ERROR: Timeout/no response (elapsed=%lu ms, resp_len=%u)\n",
+                         (unsigned long)elapsed, (unsigned)resp_len);
+                sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+            }
+            _last_error = 1; // timeout
+        }
+        else
+        {
+            if (modbus_debug_flag)
+            {
+                snprintf(dbg_buf, sizeof(dbg_buf),
+                         "[ModbusMaster] ERROR: Short/partial frame (elapsed=%lu ms, resp_len=%u)\n",
+                         (unsigned long)elapsed, (unsigned)resp_len);
+                sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+            }
+            _last_error = 2; // short frame
+        }
+        return false;
+    }
+
+    uint16_t crc_resp = resp[resp_len - 2] | (resp[resp_len - 1] << 8);
+    uint16_t crc_calc = _crc16(resp, resp_len - 2);
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] CRC received: 0x%04X, calculated: 0x%04X\n", crc_resp, crc_calc);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    if (crc_calc != crc_resp)
+    {
+        _last_error = 3;
+        if (modbus_debug_flag)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] ERROR: CRC mismatch. Calc: 0x%04X, Recv: 0x%04X\n", crc_calc, crc_resp);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+        return false;
+    }
+
+
+    if (resp[0] != _slave_id || resp[1] != 0x04)
+    {
+        _last_error = 4;
+        return false;
+    }
+
+    if (modbus_debug_flag)
+    {
+        snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Parsing %d registers:\n", count);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    for (int i = 0; i < count; i++)
+    {
+        _responseBuffer[i] = (resp[3 + 2 * i] << 8) | resp[4 + 2 * i];
+        if (modbus_debug_flag)
+        {
+            snprintf(dbg_buf, sizeof(dbg_buf), "[ModbusMaster] Register %d: 0x%04X (%d)\n", i, _responseBuffer[i], _responseBuffer[i]);
+            sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        }
+    }
+    if (modbus_debug_flag && count == 2)
+    {
+        float value = _modbus_decode_float(_responseBuffer[0], _responseBuffer[1]);
+        int rounded = (int)(value + 0.5f);
+        snprintf(dbg_buf, sizeof(dbg_buf), ">>> Decoded float value: %.4f\n", value);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+        snprintf(dbg_buf, sizeof(dbg_buf), ">>> Rounded integer value: %d\n", rounded);
+        sl_iostream_write(sl_iostream_vcom_handle, dbg_buf, strlen(dbg_buf));
+    }
+    _last_error = 0;
+    return true;
+}


### PR DESCRIPTION
This pull request adds new  drivers for DHT11/DHT22 temperature/humidity sensors and ModbusMaster RTU RS485 communication, along with their configuration headers and APIs. The changes provide flexible sensor and protocol support, backward compatibility, and integration with the platform's pin tool and documentation system.

### Board Driver Additions

* Introduced a new `dhtxx_driver` component for DHT11/DHT22 sensors with automatic protocol detection and pin tool integration, including backward-compatible names and platform documentation references.
* Added a new `modbusmaster_driver` component for ModbusMaster RTU RS485 communication, supporting register reads, DE/RE pin control, and platform documentation references.

### DHTXX Sensor Driver Implementation

* Implemented the DHTXX driver in `dhtxx.c` supporting both DHT11 and DHT22 sensors, precise microsecond timing, automatic sensor type selection, and Arduino-style API functions for easy integration.
* Provided a configuration header `sl_dhtxx_config.h` for selecting sensor type and configuring the data pin, with pin tool integration and sensor type definitions.
* Added a public API header `dhtxx.h` defining types, main API functions, and backward compatibility typedefs.

### ModbusMaster Driver Implementation

* Added a configuration header `sl_modbusmaster_config.h` for ModbusMaster driver, allowing timeout, guard time, debug output, and DE/RE pin configuration via pin tool.
* Provided a public API header `modbusmaster.h` defining buffer management, register read functions, error handling, and stream/pin control for ModbusMaster RTU communication.